### PR TITLE
Run on Windows

### DIFF
--- a/salmon/utils.py
+++ b/salmon/utils.py
@@ -10,8 +10,6 @@ import sys, os
 import logging
 if sys.platform != 'win32': # Can daemonize
     import daemon
-else:
-    import lockfile
 
 try:
     from daemon import pidlockfile 

--- a/setup.py
+++ b/setup.py
@@ -5,32 +5,22 @@ try:
 except ImportError:
     from distutils.core import setup
 
+install_requires = [
+    'chardet',
+    'jinja2',
+    'mock',
+    'nose',
+    'python-modargs',
+    'lmtpd >= 3',
+    'clevercss',
+    'markdown',
+    'pydns'
+]
+
 if sys.platform != 'win32': # Can daemonize
-    install_requires = [
-        'chardet',
-        'jinja2',
-        'mock',
-        'nose',
-        'python-daemon',
-        'python-modargs',
-        'lmtpd >= 3',
-        'clevercss',
-        'markdown',
-        'pydns'
-    ]
+    install_requires.append('python-daemon')
 else:
-    install_requires = [
-        'chardet',
-        'jinja2',
-        'mock',
-        'nose',
-        'lockfile',
-        'python-modargs',
-        'lmtpd >= 3',
-        'clevercss',
-        'markdown',
-        'pydns'
-    ]
+    install_requires.append('lockfile')
 
 config = {
     'package_data': {


### PR DESCRIPTION
This tweaks setup.py and the imports in utils.py so Salmon can be installed and run on Windows (only in --debug mode).  Obviously, this is useful mostly for development and/or testing.
