### PR TITLE
Python 3 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 source = salmon
+omit = salmon/data/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
     - "pypy"
     - "2.7"
+    - "3.5"
+    - "3.6"
 
 matrix:
   include:
@@ -12,7 +14,7 @@ matrix:
       script: tox -e $TOX_ENV
 
 install:
-    - python setup.py develop
+    - travis_retry pip install -e .
     - travis_retry pip install -q codecov
 
 script: python setup.py nosetests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@
 - Make ``LMTPReceiver`` the default in the prototype app (#48)
 - Properly work around SMTPReceiver bug caused by Python's ``smtpd`` module (#48)
   * This means that Salmon will no longer accept multiple RCPT TOs over SMTP
+- Python 3 support (#7)
+  * You'll now require ``setuptools`` to install (this won't be a problem for those upgrading)
+  * No more support for Windows - it never worked for production on that platform anyway
 
 Earlier Releases
 ================

--- a/salmon/__init__.py
+++ b/salmon/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import print_function, unicode_literals
+
 __version__ = "2.99.99"

--- a/salmon/bounce.py
+++ b/salmon/bounce.py
@@ -3,6 +3,7 @@ Bounce analysis module for Salmon.  It uses an algorithm that tries
 to simply collect the headers that are most likely found in a bounce
 message, and then determine a probability based on what it finds.
 """
+from __future__ import print_function, unicode_literals
 
 import re
 from functools import wraps

--- a/salmon/bounce.py
+++ b/salmon/bounce.py
@@ -126,7 +126,7 @@ def detect(msg):
 
     The detection algorithm is very simple but still accurate.  For each header
     it finds it adds a point to the score.  It then uses the regex in BOUNCE_MATCHERS
-    to see if the value of that header is parseable, and if it is it adds another
+    to see if the value of that header is parsable, and if it is it adds another
     point to the score.  The final probability is based on how many headers and matchers
     were found out of the total possible.
 
@@ -215,7 +215,7 @@ class BounceAnalyzer(object):
             self.diagnostic_codes = self.headers['Diagnostic-Code'][0][1:]
         else:
             self.diagnostic_codes = [None, None]
-       
+
         if 'Action' in self.headers:
             self.action = self.headers['Action'][0][0]
         else:
@@ -249,7 +249,7 @@ class BounceAnalyzer(object):
 
     def probable(self, threshold=0.3):
         """
-        Determines if this is probably a bounce based on the score 
+        Determines if this is probably a bounce based on the score
         probability.  Default threshold is 0.3 which is conservative.
         """
         return self.score > threshold
@@ -301,4 +301,3 @@ class bounce_to(object):
                 return func(message, *args, **kw)
 
         return bounce_wrapper
-

--- a/salmon/commands.py
+++ b/salmon/commands.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import argparse
 import email
 import glob
@@ -57,7 +59,12 @@ def main():
     args = _parser.parse_args()
 
     # get function reference from args and then remove it
-    cmd = args.func
+    try:
+        cmd = args.func
+    except AttributeError:
+        # python 3 only
+        raise SystemExit(2)
+
     del args.func
 
     # pass all other attrs to function as kwargs
@@ -186,16 +193,16 @@ def stop_command(parser):
             pid_files = [pid]
 
             if not os.path.exists(pid):
-                print "PID file %s doesn't exist, maybe Salmon isn't running?" % pid
+                print("PID file %s doesn't exist, maybe Salmon isn't running?" % pid)
                 sys.exit(1)
                 return  # for unit tests mocking sys.exit
 
-        print "Stopping processes with the following PID files: %s" % pid_files
+        print("Stopping processes with the following PID files: %s" % pid_files)
 
         for pid_f in pid_files:
             pid = open(pid_f).readline()
 
-            print "Attempting to stop salmon at pid %d" % int(pid)
+            print("Attempting to stop salmon at pid %d" % int(pid))
 
             try:
                 if kill:
@@ -205,7 +212,7 @@ def stop_command(parser):
 
                 os.unlink(pid_f)
             except OSError as exc:
-                print "ERROR stopping Salmon on PID %d: %s" % (int(pid), exc)
+                print("ERROR stopping Salmon on PID %d: %s" % (int(pid), exc))
 
     parser.set_defaults(func=command)
 
@@ -222,9 +229,9 @@ def status_command(parser):
     def command(pid):
         if os.path.exists(pid):
             pid = open(pid).readline()
-            print "Salmon running with PID %d" % int(pid)
+            print("Salmon running with PID %d" % int(pid))
         else:
-            print "Salmon not running."
+            print("Salmon not running.")
 
     parser.set_defaults(func=command)
 
@@ -236,25 +243,25 @@ def queue_command(parser):
     Lets you do most of the operations available to a queue.
     """
     def command(name, pop=False, get=False, keys=False, remove=False, count=False, clear=False):
-        print "Using queue: %r" % name
+        print("Using queue: %r" % name)
 
         inq = queue.Queue(name)
 
         if pop:
             key, msg = inq.pop()
             if key:
-                print "KEY: ", key
-                print msg
+                print("KEY: %s" % key)
+                print(msg)
         elif get:
-            print inq.get(get)
+            print(inq.get(get))
         elif remove:
             inq.remove(remove)
         elif count:
-            print "Queue %s contains %d messages" % (name, inq.count())
+            print("Queue %s contains %d messages" % (name, inq.count()))
         elif clear:
             inq.clear()
         elif keys:
-            print "\n".join(inq.keys())
+            print("\n".join(inq.keys()))
 
     parser.set_defaults(func=command)
 
@@ -283,26 +290,26 @@ def routes_command(parser):
         for module in modules:
             __import__(module, globals(), locals())
 
-        print "Routing ORDER: ", routing.Router.ORDER
-        print "Routing TABLE: \n---"
+        print("Routing ORDER: ", routing.Router.ORDER)
+        print("Routing TABLE: \n---")
         for format in routing.Router.REGISTERED:
-            print "%r: " % format,
+            print("%r: " % format, end="")
             regex, functions = routing.Router.REGISTERED[format]
             for func in functions:
-                print "%s.%s " % (func.__module__, func.__name__),
+                print("%s.%s " % (func.__module__, func.__name__), end="")
                 match = regex.match(test)
                 if test and match:
                     test_case_matches.append((format, func, match))
 
-            print "\n---"
+            print("\n---")
 
         if test_case_matches:
-            print "\nTEST address %r matches:" % test
+            print("\nTEST address %r matches:" % test)
             for format, func, match in test_case_matches:
-                print "  %r %s.%s" % (format, func.__module__, func.__name__)
-                print "  -  %r" % (match.groupdict())
+                print("  %r %s.%s" % (format, func.__module__, func.__name__))
+                print("  -  %r" % (match.groupdict()))
         elif test:
-            print "\nTEST address %r didn't match anything." % test
+            print("\nTEST address %r didn't match anything." % test)
 
     parser.set_defaults(func=command)
 
@@ -319,7 +326,7 @@ def gen_command(parser):
         template = os.path.join(salmon.__path__[0], "data", "prototype")
 
         if os.path.exists(project) and not force:
-            print "Project %s exists, delete it first." % project
+            print("Project %s exists, delete it first." % project)
             sys.exit(1)
             return
         elif force:
@@ -353,14 +360,14 @@ def cleanse_command(parser):
             try:
                 mail = encoding.from_message(msg)
                 outbox.add(encoding.to_string(mail))
-            except encoding.EncodingError, exc:
-                print "ERROR: ", exc
+            except encoding.EncodingError as exc:
+                print("ERROR: %s" % exc)
                 error_count += 1
 
         outbox.close()
         inbox.close()
 
-        print "TOTAL ERRORS:", error_count
+        print("TOTAL ERRORS: %s" % error_count)
 
     parser.set_defaults(func=command)
 
@@ -405,6 +412,6 @@ _subparsers = _parser.add_subparsers(metavar="<command>")
 
 for cmd, help_txt in COMMANDS:
     function = globals()["{0}_command".format(cmd)]
-    cmd_parser = _subparsers.add_parser(cmd, description=function.func_doc,
+    cmd_parser = _subparsers.add_parser(cmd, description=function.__doc__,
             help=help_txt, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     function(cmd_parser)

--- a/salmon/commands.py
+++ b/salmon/commands.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import argparse
 import email

--- a/salmon/commands.py
+++ b/salmon/commands.py
@@ -14,7 +14,7 @@ import salmon
 
 
 COMMANDS = (
-    ("start", "starts aserver"),
+    ("start", "starts a server"),
     ("stop", "stops a server"),
     ("status", "displays status of server"),
     ("gen", "generate new project"),
@@ -343,8 +343,8 @@ def gen_command(parser):
 def cleanse_command(parser):
     """
     Uses Salmon mail cleansing and canonicalization system to take an
-    input maildir (or mbox) and replicate the email over into another
-    maildir.  It's used mostly for testing and cleaning.
+    input Maildir (or mbox) and replicate the email over into another
+    Maildir.  It's used mostly for testing and cleaning.
     """
     def command(input, output):
         error_count = 0
@@ -371,13 +371,13 @@ def cleanse_command(parser):
 
     parser.set_defaults(func=command)
 
-    parser.add_argument("input", help="input maildir or mbox")
-    parser.add_argument("output", help="output maildir")
+    parser.add_argument("input", help="input Maildir or mbox")
+    parser.add_argument("output", help="output Maildir")
 
 
 def blast_command(parser):
     """
-    Given a maildir, this command will go through each email
+    Given a Maildir, this command will go through each email
     and blast it at your server.  It does nothing to the message, so
     it will be real messages hitting your server, not cleansed ones.
     """
@@ -396,7 +396,7 @@ def blast_command(parser):
 
     parser.set_defaults(func=command)
 
-    parser.add_argument("input", help="input maildir or mbox")
+    parser.add_argument("input", help="input Maildir or mbox")
     parser.add_argument("--port", default=8823, type=int, help="port to listen on")
     parser.add_argument("--host", default="127.0.0.1", help="address to listen on")
     parser.add_argument("--lmtp", action="store_true", default=argparse.SUPPRESS)

--- a/salmon/commands.py
+++ b/salmon/commands.py
@@ -59,12 +59,7 @@ def main():
     args = _parser.parse_args()
 
     # get function reference from args and then remove it
-    try:
-        cmd = args.func
-    except AttributeError:
-        # python 3 only
-        raise SystemExit(2)
-
+    cmd = args.func
     del args.func
 
     # pass all other attrs to function as kwargs
@@ -409,6 +404,7 @@ _parser = argparse.ArgumentParser(description="Python mail server", epilog=copyr
 
 _parser.add_argument("-v", "--version", action="version", version=version_info)
 _subparsers = _parser.add_subparsers(metavar="<command>")
+_subparsers.required = True
 
 for cmd, help_txt in COMMANDS:
     function = globals()["{0}_command".format(cmd)]

--- a/salmon/confirm.py
+++ b/salmon/confirm.py
@@ -45,7 +45,7 @@ class ConfirmationStorage(object):
         your own you don't need this.
 
         NOTE: To support proper equality and shelve storage, this encodes the
-        key into ASCII.  Make a different subclass if you need unicode and your
+        key into ASCII.  Make a different subclass if you need Unicode and your
         storage supports it.
         """
         key = target + ':' + from_address

--- a/salmon/confirm.py
+++ b/salmon/confirm.py
@@ -13,6 +13,7 @@ provide the logic for doing the following:
 You then just work this into your project's state flow, write your own
 templates, and possibly write your own storage.
 """
+from __future__ import print_function, unicode_literals
 
 import uuid
 from salmon import queue, view

--- a/salmon/encoding.py
+++ b/salmon/encoding.py
@@ -305,7 +305,7 @@ class MIMEPart(Message):
         self.set_payload(encoded, charset=charset)
 
     def extract_payload(self, mail):
-        if mail.body == None:
+        if mail.body is None:
             return  # only None, '' is still ok
 
         ctype, ctype_params = mail.content_encoding['Content-Type']
@@ -481,7 +481,7 @@ def header_to_mime_encoding(value, not_email=False):
     if not value: return ""
 
     encoder = Charset(DEFAULT_ENCODING)
-    if type(value) == list:
+    if isinstance(value, list):
         return "; ".join(properly_encode_header(v, encoder, not_email) for v in value)
     else:
         return properly_encode_header(value, encoder, not_email)
@@ -490,7 +490,7 @@ def header_to_mime_encoding(value, not_email=False):
 def header_from_mime_encoding(header):
     if header is None:
         return header
-    elif type(header) == list:
+    elif isinstance(header, list):
         return [properly_decode_header(h) for h in header]
     elif isinstance(header, email.header.Header):
         return six.text_type(header)

--- a/salmon/encoding.py
+++ b/salmon/encoding.py
@@ -64,6 +64,7 @@ email is not formatted right and/or spam.
 If you find an instance where this is not the case, then submit it to the
 project as a test case.
 """
+from __future__ import print_function, unicode_literals
 
 from email import encoders
 from email.charset import Charset

--- a/salmon/encoding.py
+++ b/salmon/encoding.py
@@ -3,13 +3,13 @@ Salmon takes the policy that email it receives is most likely complete garbage
 using bizarre pre-Unicode formats that are irrelevant and unnecessary in today's
 modern world.  These emails must be cleansed of their unholy stench of
 randomness and turned into something nice and clean that a regular Python
-programmer can work with:  unicode.
+programmer can work with:  Unicode.
 
 That's the receiving end, but on the sending end Salmon wants to make the world
 better by not increasing the suffering.  To that end, Salmon will canonicalize
 all email it sends to be ascii or utf-8 (whichever is simpler and works to
 encode the data).  When you get an email from Salmon, it is a pristine easily
-parseable clean unit of goodness you can count on.
+parsable clean unit of goodness you can count on.
 
 To accomplish these tasks, Salmon goes back to basics and assert a few simple
 rules on each email it receives:
@@ -25,12 +25,12 @@ rules on each email it receives:
 6) It does this by decoding all codecs, and if the codec LIES, then it will
    attempt to statistically detect the codec using chardet.
 7) If it can't detect the codec, and the codec lies, then the email is bad.
-8) All text bodies and attachments are then converted to Python unicode in the
-   same way as the headers.
+8) All text bodies and attachments are then converted to Python unicode/str
+   (for Python 2.7 and 3.x respectively) in the same way as the headers.
 9) All other attachments are converted to raw strings as-is.
 
 Once Salmon has done this, your Python handler can now assume that all
-MailRequest objects are happily unicode enabled and ready to go.  The rule is:
+MailRequest objects are happily Unicode enabled and ready to go.  The rule is:
 
     IF IT CANNOT BE UNICODE, THEN PYTHON CANNOT WORK WITH IT.
 
@@ -461,7 +461,7 @@ def properly_encode_header(value, encoder, not_email):
     addresses by changing the '@' to '-AT-'.  This is where
     VALUE_IS_EMAIL_ADDRESS exists.  It's a simple lambda returning True/False
     to check if a header value has an email address.  If you need to make this
-    checVk different, then change this.
+    check different, then change this.
     """
     # i suspect this function and those that call it are doing too much
     # TODO: investigate

--- a/salmon/handlers/queue.py
+++ b/salmon/handlers/queue.py
@@ -1,7 +1,7 @@
 """
-Implements a handler that puts every message it receives into 
+Implements a handler that puts every message it receives into
 the run/queue directory.  It is intended as a debug tool so you
-can inspect messages the server is receiving using mutt or 
+can inspect messages the server is receiving using mutt or
 the salmon queue command.
 """
 
@@ -15,7 +15,7 @@ import logging
 def START(message, to=None, host=None):
     """
     @stateless and routes however handlers.log.START routes (everything).
-    Has @nolocking, but that's alright since it's just writing to a maildir.
+    Has @nolocking, but that's alright since it's just writing to a Maildir.
     """
     q = queue.Queue('run/queue')
     q.push(message)

--- a/salmon/mail.py
+++ b/salmon/mail.py
@@ -33,8 +33,16 @@ def _decode_header_randomness(addr):
     if not addr:
         return set()
     elif isinstance(addr, list):
-        return set(parseaddr(a.lower())[1] for a in addr)
+        addr_set = set()
+        for a in addr:
+            for returned_addr in _decode_header_randomness(a):
+                addr_set.add(returned_addr)
+
+        return addr_set
     elif isinstance(addr, six.string_types):
+        return set([parseaddr(addr.lower())[1]])
+    elif isinstance(addr, six.binary_type):
+        addr = addr.decode()
         return set([parseaddr(addr.lower())[1]])
     else:
         raise encoding.EncodingError("Address must be a string or a list not: %r", type(addr))

--- a/salmon/mail.py
+++ b/salmon/mail.py
@@ -9,7 +9,7 @@ that you've received, so it doesn't have functions for attaching files and such.
 MailResponse is used when you are going to write an email, so it has the
 APIs for doing attachments and such.
 """
-
+from __future__ import print_function, unicode_literals
 
 from email.utils import parseaddr
 import mimetypes

--- a/salmon/mail.py
+++ b/salmon/mail.py
@@ -1,21 +1,24 @@
 """
 The salmon.mail module contains nothing more than wrappers around the big work
 done in salmon.encoding.  These are the actual APIs that you'll interact with
-when doing email, and they mostly replicate the salmon.encoding.MailBase 
+when doing email, and they mostly replicate the salmon.encoding.MailBase
 functionality.
 
-The main design criteria is that MailRequest is mostly for reading email 
+The main design criteria is that MailRequest is mostly for reading email
 that you've received, so it doesn't have functions for attaching files and such.
 MailResponse is used when you are going to write an email, so it has the
 APIs for doing attachments and such.
 """
 
 
-import mimetypes
-from salmon import encoding, bounce
 from email.utils import parseaddr
+import mimetypes
 import os
 import warnings
+
+import six
+
+from salmon import encoding, bounce
 
 
 # You can change this to 'Delivered-To' on servers that support it like Postfix
@@ -24,14 +27,14 @@ ROUTABLE_TO_HEADER='to'
 
 def _decode_header_randomness(addr):
     """
-    This fixes the given address so that it is *always* a set() of 
+    This fixes the given address so that it is *always* a set() of
     just email addresses suitable for routing.
     """
     if not addr:
         return set()
     elif isinstance(addr, list):
         return set(parseaddr(a.lower())[1] for a in addr)
-    elif isinstance(addr, basestring):
+    elif isinstance(addr, six.string_types):
         return set([parseaddr(addr.lower())[1]])
     else:
         raise encoding.EncodingError("Address must be a string or a list not: %r", type(addr))
@@ -40,7 +43,7 @@ def _decode_header_randomness(addr):
 class MailRequest(object):
     """
     This is what older users of Salmon are accustomed to.  The information
-    you get out of this is *ALWAYS* in Python unicode and should be usable 
+    you get out of this is *ALWAYS* in Python unicode and should be usable
     by any API.  Modifying this object will cause other handlers that deal
     with it to get your modifications, but in general you don't want to do
     more than maybe tag a few headers.
@@ -118,7 +121,7 @@ class MailRequest(object):
 
     def __str__(self):
         """
-        Converts this to a string usable for storage into a queue or 
+        Converts this to a string usable for storage into a queue or
         transmission.
         """
         return encoding.to_string(self.Email)
@@ -140,7 +143,7 @@ class MailRequest(object):
 
     def is_bounce(self, threshold=0.3):
         """
-        Determines whether the message is a bounce message based on 
+        Determines whether the message is a bounce message based on
         salmon.bounce.BounceAnalzyer given threshold.  0.3 is a good
         conservative base.
         """
@@ -208,7 +211,7 @@ class MailResponse(object):
         data/content_type/filename/disposition combination.
 
         For convenience, if you don't give data and only a filename, then it
-        will read that file's contents when you call to_message() later.  If you 
+        will read that file's contents when you call to_message() later.  If you
         give data and filename then it will assume you've filled data with what
         the file's contents are and filename is just the name to use.
         """

--- a/salmon/mail.py
+++ b/salmon/mail.py
@@ -42,11 +42,11 @@ def _decode_header_randomness(addr):
 
 class MailRequest(object):
     """
-    This is what older users of Salmon are accustomed to.  The information
-    you get out of this is *ALWAYS* in Python unicode and should be usable
-    by any API.  Modifying this object will cause other handlers that deal
-    with it to get your modifications, but in general you don't want to do
-    more than maybe tag a few headers.
+    This is what older users of Salmon are accustomed to.  The information you
+    get out of this is *ALWAYS* in Python str (unicode in Python 2.7) and
+    should be usable by any API.  Modifying this object will cause other
+    handlers that deal with it to get your modifications, but in general you
+    don't want to do more than maybe tag a few headers.
     """
     def __init__(self, Peer, From, To, Data):
         """

--- a/salmon/queue.py
+++ b/salmon/queue.py
@@ -4,6 +4,7 @@ do get a lot more features from the Python library, so if you need
 to do some serious surgery go use that.  This works as a good
 API for the 90% case of "put mail in, get mail out" queues.
 """
+from __future__ import print_function, unicode_literals
 
 import errno
 import hashlib

--- a/salmon/queue.py
+++ b/salmon/queue.py
@@ -53,7 +53,7 @@ class QueueError(Exception):
 class Queue(object):
     """
     Provides a simplified API for dealing with 'queues' in Salmon.
-    It currently just supports maildir queues since those are the
+    It currently just supports Maildir queues since those are the
     most robust, but could implement others later.
     """
 
@@ -68,7 +68,7 @@ class Queue(object):
         processing is done and is based on the size of the file on disk.  The
         purpose is to prevent people from sending 10MB attachments.  If a
         message is over the pop_limit then it is placed into the
-        oversize_dir (which should be a maildir).
+        oversize_dir (which should be a Maildir).
 
         The oversize protection only works on pop messages off, not
         putting them in, get, or any other call.  If you use get you can

--- a/salmon/queue.py
+++ b/salmon/queue.py
@@ -17,7 +17,7 @@ from salmon import mail
 
 # we calculate this once, since the hostname shouldn't change for every
 # email we put in a queue
-HASHED_HOSTNAME = hashlib.md5(socket.gethostname()).hexdigest()
+HASHED_HOSTNAME = hashlib.md5(socket.gethostname().encode("utf-8")).hexdigest()
 
 class SafeMaildir(mailbox.Maildir):
     def _create_tmp(self):
@@ -27,12 +27,12 @@ class SafeMaildir(mailbox.Maildir):
         path = os.path.join(self._path, 'tmp', uniq)
         try:
             os.stat(path)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 mailbox.Maildir._count += 1
                 try:
                     return mailbox._create_carefully(path)
-                except OSError, e:
+                except OSError as e:
                     if e.errno != errno.EEXIST:
                         raise
             else:
@@ -53,7 +53,7 @@ class QueueError(Exception):
 class Queue(object):
     """
     Provides a simplified API for dealing with 'queues' in Salmon.
-    It currently just supports maildir queues since those are the 
+    It currently just supports maildir queues since those are the
     most robust, but could implement others later.
     """
 
@@ -117,13 +117,13 @@ class Queue(object):
                                 key, self.pop_limit, self.oversize_dir)
                     os.rename(over_name, os.path.join(self.oversize_dir, key))
                 else:
-                    logging.info("Message key %s over size limit %d, DELETING (set oversize_dir).", 
+                    logging.info("Message key %s over size limit %d, DELETING (set oversize_dir).",
                                 key, self.pop_limit)
                     os.unlink(over_name)
             else:
                 try:
                     msg = self.get(key)
-                except QueueError, exc:
+                except QueueError as exc:
                     raise exc
                 finally:
                     self.remove(key)
@@ -138,14 +138,14 @@ class Queue(object):
         """
         msg_file = self.mbox.get_file(key)
 
-        if not msg_file: 
+        if not msg_file:
             return None
 
         msg_data = msg_file.read()
 
         try:
             return mail.MailRequest(self.dir, None, None, msg_data)
-        except Exception, exc:
+        except Exception as exc:
             logging.exception("Failed to decode message: %s; msg_data: %r",   exc, msg_data)
             return None
 
@@ -153,7 +153,7 @@ class Queue(object):
     def remove(self, key):
         """Removes the queue, but not returned."""
         self.mbox.remove(key)
-    
+
     def count(self):
         """Returns the number of messages in the queue."""
         return len(self.mbox)
@@ -167,7 +167,7 @@ class Queue(object):
         # man this is probably a really bad idea
         while self.count() > 0:
             self.pop()
-    
+
     def keys(self):
         """
         Returns the keys in the queue.
@@ -180,6 +180,3 @@ class Queue(object):
             return os.path.getsize(file_name) > self.pop_limit, file_name
         else:
             return False, None
-
-
-

--- a/salmon/routing.py
+++ b/salmon/routing.py
@@ -1,4 +1,3 @@
-
 """
 The meat of Salmon, doing all the work that actually takes an email and makes
 sure that your code gets it.
@@ -49,6 +48,7 @@ after that.
 The @state_key_generator is different since it's not intended to go on a handler
 but instead on a simple function, so it shouldn't be combined with the others.
 """
+from __future__ import print_function, unicode_literals
 
 from functools import wraps
 import re

--- a/salmon/routing.py
+++ b/salmon/routing.py
@@ -58,6 +58,15 @@ import email.utils
 import shelve
 import threading
 
+try:
+    from importlib import reload
+except ImportError:
+    try:
+        from imp import reload
+    except ImportError:
+        from __builtin__ import reload
+
+
 ROUTE_FIRST_STATE = 'START'
 LOG = logging.getLogger("routing")
 DEFAULT_STATE_KEY = lambda mod, msg: mod

--- a/salmon/routing.py
+++ b/salmon/routing.py
@@ -102,7 +102,7 @@ class MemoryStorage(StateStorage):
     """
     The default simplified storage for the Router to hold the states.  This
     should only be used in testing, as you'll lose all your contacts and their
-    states if your server shutsdown.  It is also horribly NOT thread safe.
+    states if your server shuts down.  It is also horribly NOT thread safe.
     """
     def __init__(self):
         self.states = {}
@@ -516,7 +516,7 @@ class route(object):
         raise NotImplementedError("Not supported on methods yet, only module functions.")
 
     def parse_format(self, format, captures):
-        """Does the grunt work of convertion format+captures into the regex."""
+        """Does the grunt work of conversion format+captures into the regex."""
         for key in captures:
             format = format.replace("(" + key + ")", "(?P<%s>%s)" % (key, captures[key]))
         return "^" + format + "$"
@@ -566,7 +566,7 @@ def stateless(func):
     This is how you create a handler that processes all messages matching the
     given format+captures in a @route.
 
-    Another way to think about a @stateless handler is that it is a passthrough
+    Another way to think about a @stateless handler is that it is a pass-through
     handler that does its processing and then passes the results on to others.
 
     Stateless handlers are NOT guaranteed to run before the handler with state.
@@ -582,7 +582,7 @@ def stateless(func):
 def nolocking(func):
     """
     Normally salmon.routing.Router has a lock around each call to all handlers
-    to prevent them from stepping on eachother.  It's assumed that 95% of the
+    to prevent them from stepping on each other.  It's assumed that 95% of the
     time this is what you want, so it's the default.  You probably want
     everything to go in order and not step on other things going off from other
     threads in the system.

--- a/salmon/routing.py
+++ b/salmon/routing.py
@@ -61,10 +61,7 @@ import threading
 try:
     from importlib import reload
 except ImportError:
-    try:
-        from imp import reload
-    except ImportError:
-        from __builtin__ import reload
+    from __builtin__ import reload
 
 
 ROUTE_FIRST_STATE = 'START'

--- a/salmon/server.py
+++ b/salmon/server.py
@@ -195,7 +195,7 @@ class SMTPReceiver(smtpd.SMTPServer):
 
     def __init__(self, host='127.0.0.1', port=8825):
         """
-        Initializes to bind on the given port and host/ipaddress.  Typically
+        Initializes to bind on the given port and host/IP address.  Typically
         in deployment you'd give 0.0.0.0 for "all internet devices" but consult
         your operating system.
 
@@ -253,7 +253,7 @@ class LMTPReceiver(lmtpd.LMTPServer):
 
     def __init__(self, host='127.0.0.1', port=8824, socket=None):
         """
-        Initializes to bind on the given port and host/ipaddress. Remember that
+        Initializes to bind on the given port and host/IP address. Remember that
         LMTP isn't for use over a WAN, so bind it to either a LAN address or
         localhost. If socket is not None, it will be assumed to be a path name
         and a UNIX socket will be set up instead.
@@ -308,7 +308,7 @@ class LMTPReceiver(lmtpd.LMTPServer):
 class QueueReceiver(object):
     """
     Rather than listen on a socket this will watch a queue directory and
-    process messages it recieves from that.  It works in almost the exact
+    process messages it receives from that.  It works in almost the exact
     same way otherwise.
     """
 

--- a/salmon/server.py
+++ b/salmon/server.py
@@ -2,6 +2,7 @@
 The majority of the server related things Salmon needs to run, like receivers,
 relays, and queue processors.
 """
+from __future__ import print_function, unicode_literals
 
 import asyncore
 import logging

--- a/salmon/testing.py
+++ b/salmon/testing.py
@@ -19,7 +19,7 @@ modules (not just your handlers) will get reloaded.
 The spelling function will use PyEnchant to spell check a string.  If it finds
 any errors it prints them out, and returns False.
 """
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import re
 

--- a/salmon/testing.py
+++ b/salmon/testing.py
@@ -19,11 +19,15 @@ modules (not just your handlers) will get reloaded.
 The spelling function will use PyEnchant to spell check a string.  If it finds
 any errors it prints them out, and returns False.
 """
+from __future__ import print_function
+
+import re
+
+import six
 
 from salmon import server, routing, mail
 from salmon.queue import Queue
 from nose.tools import assert_equal
-import re
 
 TEST_QUEUE = "run/queue"
 
@@ -43,18 +47,18 @@ def spelling(file_name, contents, language="en_US"):
         from enchant.checker import SpellChecker
         from enchant.tokenize import EmailFilter, URLFilter
     except ImportError:
-        print "Failed to load PyEnchant.  Make sure it's installed and salmon spell works."
+        print("Failed to load PyEnchant.  Make sure it's installed and salmon spell works.")
         return True
 
     failures = 0
     chkr = SpellChecker(language, filters=[EmailFilter, URLFilter])
     chkr.set_text(contents)
     for err in chkr:
-        print "%s: %s \t %r" % (file_name, err.word, contents[err.wordpos - 20:err.wordpos + 20])
+        print("%s: %s \t %r" % (file_name, err.word, contents[err.wordpos - 20:err.wordpos + 20]))
         failures += 1
 
     if failures:
-        print "You have %d spelling errors in %s.  Run salmon spell.." % (failures, file_name)
+        print("You have %d spelling errors in %s.  Run salmon spell.." % (failures, file_name))
         return False
     else:
         return True
@@ -92,7 +96,7 @@ def delivered(pattern, to_queue=None):
             return False
 
         regp = re.compile(pattern)
-        if regp.search(str(msg)):
+        if regp.search(pattern.__class__(msg)):
             msg = inq.get(key)
             return msg
 
@@ -136,11 +140,11 @@ class TestConversation(object):
         if expect:
             msg = delivered(expect)
             if not msg:
-                print "MESSAGE IN QUEUE:"
+                print("MESSAGE IN QUEUE:")
                 inq = queue()
                 for key in inq.keys():
-                    print "-----"
-                    print inq.get(key)
+                    print("-----")
+                    print(inq.get(key))
 
             assert msg, "Expected %r when sending to %r with '%s:%s' message." % (expect,
                                                                                   To, self.Subject or Subject, Body)
@@ -175,5 +179,3 @@ def assert_in_state(module, To, From, state):
     fake = {'to': To}
     state_key = routing.Router.state_key(module, fake)
     assert_equal(routing.Router.STATE_STORE.get(state_key, From), state)
-
-

--- a/salmon/utils.py
+++ b/salmon/utils.py
@@ -4,7 +4,7 @@ really belong anywhere else in the modules.  This module
 is kind of a dumping ground, so if you find something that
 can be improved feel free to work up a patch.
 """
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import imp
 import importlib

--- a/salmon/utils.py
+++ b/salmon/utils.py
@@ -4,6 +4,7 @@ really belong anywhere else in the modules.  This module
 is kind of a dumping ground, so if you find something that
 can be improved feel free to work up a patch.
 """
+from __future__ import print_function
 
 import imp
 import importlib
@@ -101,7 +102,7 @@ def check_for_pid(pid, force):
     then it will remove the file and not exit if it's there."""
     if os.path.exists(pid):
         if not force:
-            print "PID file %s exists, so assuming Salmon is running.  Give -FORCE to force it to start." % pid
+            print("PID file %s exists, so assuming Salmon is running.  Give -FORCE to force it to start." % pid)
             sys.exit(1)
         else:
             os.unlink(pid)
@@ -129,7 +130,7 @@ def start_server(pid, force, chroot, chdir, uid, gid, umask, settings_loader, de
     settings.receiver.start()
 
     if debug:
-        print "Salmon started in debug mode. ctrl-c to quit..."
+        print("Salmon started in debug mode. ctrl-c to quit...")
         import time
         try:
             while True:

--- a/salmon/view.py
+++ b/salmon/view.py
@@ -52,14 +52,14 @@ def respond(variables, Body=None, Html=None, **kwd):
                           Html='template.html',
                           From='test@test.com',
                           To='receiver@test.com',
-                          Subject='Test body from "%(dude)s".')
+                          Subject='Test body from "%(person)s".')
 
     In this case you're using locals() to gather the variables needed for
     the 'template.txt' and 'template.html' templates.  Each template is
     setup to be a text/plain or text/html attachment.  The From/To/Subject
     are setup as needed.  Finally, the locals() are also available as
     simple Python keyword templates in the From/To/Subject so you can pass
-    in variables to modify those when needed (as in the %(dude)s in Subject).
+    in variables to modify those when needed (as in the %(person)s in Subject).
     """
 
     assert Body or Html, "You need to give either the Body or Html template of the mail."

--- a/salmon/view.py
+++ b/salmon/view.py
@@ -5,6 +5,7 @@ the template loaders in your boot module.
 
 After that these functions should just work.
 """
+from __future__ import print_function, unicode_literals
 
 from salmon import mail
 import email

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,19 @@
 import sys
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 install_requires = [
     'chardet',
     'lmtpd>=4',
-    'dnspython',
+    'python-daemon',
+    'six',
 ]
 
-if sys.platform != 'win32':  # Can daemonize
-    install_requires.append('python-daemon<1.7')
-else:
-    install_requires.append('lockfile')
+
+if sys.version_info[0] == 2:
+    install_requires.append('dnspython')
+elif sys.version_info[0] == 3:
+    install_requires.append('dnspython3')
 
 test_requires = [
     'coverage',
@@ -48,7 +47,7 @@ config = {
         'Topic :: Communications :: Email',
         'Topic :: Software Development :: Libraries :: Application Frameworks'
         ],
-    "entry_points": {
+    'entry_points': {
         'console_scripts':
             ['salmon = salmon.commands:main'],
     },

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,13 @@
-import sys
-
 from setuptools import setup
+
 
 install_requires = [
     'chardet',
+    'dnspython',
     'lmtpd>=4',
     'python-daemon',
     'six',
 ]
-
-
-if sys.version_info[0] == 2:
-    install_requires.append('dnspython')
-elif sys.version_info[0] == 3:
-    install_requires.append('dnspython3')
 
 test_requires = [
     'coverage',

--- a/tests/salmon_tests/encoding_tests.py
+++ b/tests/salmon_tests/encoding_tests.py
@@ -176,7 +176,7 @@ def test_headers_round_trip():
         original = encoding.header_from_mime_encoding(header)
 
         assert original
-        assert "=?" not in original and "?=" not in original, "Didn't decode: %r" % (encoding.SCANNER.scan(header),)
+        assert "=?" not in original and "?=" not in original, "Didn't decode: %r" % header
 
         encoded = encoding.header_to_mime_encoding(original)
         assert encoded

--- a/tests/salmon_tests/handlers/simple_fsm_mod.py
+++ b/tests/salmon_tests/handlers/simple_fsm_mod.py
@@ -9,7 +9,7 @@ def simple_key_gen(module_name, message):
 
 
 # common routing capture regexes go in here, you can override them in @route
-Router.defaults(host="localhost", 
+Router.defaults(host="localhost",
                 action="[a-zA-Z0-9]+",
                 list_name="[a-zA-Z.0-9]+")
 
@@ -22,7 +22,7 @@ def START(message, list_name=None, action=None, host=None):
         raise RuntimeError("Exploded on purpose.")
     return CONFIRM
 
-    
+
 @route("(list_name)-confirm-(id_number)@(host)", id_number="[0-9]+")
 def CONFIRM(message, list_name=None, id_number=None, host=None):
     print("CONFIRM", message, list_name, id_number, host)

--- a/tests/salmon_tests/handlers/simple_fsm_mod.py
+++ b/tests/salmon_tests/handlers/simple_fsm_mod.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from salmon.routing import *
 
 
@@ -14,34 +16,34 @@ Router.defaults(host="localhost",
 
 @route("(list_name)-(action)@(host)")
 def START(message, list_name=None, action=None, host=None):
-    print "START", message, list_name, action, host
+    print("START", message, list_name, action, host)
     if action == 'explode':
-        print "EXPLODE!"
+        print("EXPLODE!")
         raise RuntimeError("Exploded on purpose.")
     return CONFIRM
 
     
 @route("(list_name)-confirm-(id_number)@(host)", id_number="[0-9]+")
 def CONFIRM(message, list_name=None, id_number=None, host=None):
-    print "CONFIRM", message, list_name, id_number, host
+    print("CONFIRM", message, list_name, id_number, host)
     return POSTING
 
 
 @route("(list_name)-(action)@(host)")
 def POSTING(message, list_name=None, action=None, host=None):
-    print "POSTING", message, list_name, action, host
+    print("POSTING", message, list_name, action, host)
     return NEXT
 
 
 @route_like(POSTING)
 def NEXT(message, list_name=None, action=None, host=None):
-    print "NEXT", message, list_name, action, host
+    print("NEXT", message, list_name, action, host)
     return END
 
 
 @route("(anything)@(host)", anything=".*")
 def END(message, anything=None, host=None):
-    print "END", anything, host
+    print("END", anything, host)
     return START
 
 
@@ -49,7 +51,7 @@ def END(message, anything=None, host=None):
 @stateless
 @nolocking
 def PASSING(message, *args, **kw):
-    print "PASSING", args, kw
+    print("PASSING", args, kw)
 
 
 try:
@@ -57,7 +59,7 @@ try:
     @stateless
     @route("badstateless@(host)")
     def BAD_STATELESS(message, *args, **kw):
-        print "BAD_STATELESS", args, kw
+        print("BAD_STATELESS", args, kw)
 except AssertionError:
     pass
 else:

--- a/tests/salmon_tests/message_tests.py
+++ b/tests/salmon_tests/message_tests.py
@@ -255,6 +255,15 @@ def test_to_from_works():
 
 def test_decode_header_randomness():
     assert_equal(mail._decode_header_randomness(None), set())
+
+    # with strings
     assert_equal(mail._decode_header_randomness(["z@localhost", '"Z A" <z@localhost>']), set(["z@localhost", "z@localhost"]))
     assert_equal(mail._decode_header_randomness("z@localhost"), set(["z@localhost"]))
+
+    # with bytes
+    assert_equal(mail._decode_header_randomness([b"z@localhost", b'"Z A" <z@localhost>']), set(["z@localhost", "z@localhost"]))
+    assert_equal(mail._decode_header_randomness(b"z@localhost"), set(["z@localhost"]))
+
+    # with literal nonsense
     assert_raises(encoding.EncodingError, mail._decode_header_randomness, 1)
+    assert_raises(encoding.EncodingError, mail._decode_header_randomness, [1, "m@localhost"])

--- a/tests/salmon_tests/message_tests.py
+++ b/tests/salmon_tests/message_tests.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2008 Zed A. Shaw.  Licensed under the terms of the GPLv3.
+from __future__ import print_function
+
 from nose.tools import assert_equal, assert_raises
 
 from salmon import mail, encoding
@@ -48,7 +50,7 @@ def test_mail_request():
     assert_equal(msg['from'], msg['fRom'])
 
     # make sure repr runs
-    print repr(msg)
+    print(repr(msg))
 
     return msg
 
@@ -150,7 +152,7 @@ def test_mail_response_mailing_list_headers():
 
     msg = mail.MailResponse(From='somedude@localhost', To=list_addr, Subject='subject', Body="Mailing list reply.")
 
-    print repr(msg)
+    print(repr(msg))
 
     msg["Sender"] = list_addr
     msg["Reply-To"] = list_addr
@@ -166,7 +168,7 @@ def test_mail_response_mailing_list_headers():
 
     headers = ['Sender', 'Reply-To', 'List-Id', 'Return-Path', 'In-Reply-To', 'References', 'Precedence']
     for header in headers:
-        assert msg[header] == req[header]
+        assert msg[header] == req[header], "%s != %s" % (msg[header], req[header])
 
     # try a delete
     del msg['Precedence']

--- a/tests/salmon_tests/queue_tests.py
+++ b/tests/salmon_tests/queue_tests.py
@@ -47,10 +47,10 @@ def test_pop():
 
     assert hasattr(msg, "Data"), "MailRequest doesn't have Data attribute"
 
-    assert msg['to'] == "test@localhost"
-    assert msg['from'] == "test@localhost"
-    assert msg['subject'] == "Test"
-    assert msg.body() == "Test"
+    assert msg['to'] == "test@localhost", "%s != 'test@locahost'" % msg['to']
+    assert msg['from'] == "test@localhost", "%s != 'test@locahost'" % msg['from']
+    assert msg['subject'] == "Test", "%s != 'Test'" % msg['subject']
+    assert msg.body() == "Test", "%s != 'Test'" % msg.body()
 
     assert q.count() == 0, "Queue should be empty."
     assert not q.pop()[0]
@@ -125,13 +125,10 @@ def test_oversize_protections():
     overq.clear()
 
 
+@with_setup(setup_salmon_dirs, teardown_salmon_dirs)
 @patch('os.stat', new=Mock())
 @raises(mailbox.ExternalClashError)
 def test_SafeMaildir_name_clash():
-    try:
-        shutil.rmtree("run/queue")
-    except EnvironmentError:
-        pass
     sq = queue.SafeMaildir('run/queue')
     sq.add("TEST")
 
@@ -151,14 +148,10 @@ def test_SafeMaildir_throws_errno_failure():
     sq.add("TEST")
 
 
+@with_setup(setup_salmon_dirs, teardown_salmon_dirs)
 @patch('os.stat', new=Mock())
 @raises(OSError)
 def test_SafeMaildir_reraise_weird_errno():
-    try:
-        shutil.rmtree("run/queue")
-    except EnvironmentError:
-        pass
-
     os.stat.side_effect = raise_OSError
     sq = queue.SafeMaildir('run/queue')
     sq.add('TEST')

--- a/tests/salmon_tests/routing_tests.py
+++ b/tests/salmon_tests/routing_tests.py
@@ -23,7 +23,7 @@ def test_MemoryStorage():
 
 
 def test_ShelveStorage():
-    store = ShelveStorage("tests/states.db")
+    store = ShelveStorage("run/states.db")
 
     store.set(test_ShelveStorage.__module__, "tester@localhost", "TESTED")
     assert store.get(test_MemoryStorage.__module__, "tester@localhost") == "TESTED"
@@ -41,7 +41,7 @@ def test_RoutingBase():
     assert len(Router.REGISTERED) == 0
 
     setup_router(['salmon_tests.handlers.simple_fsm_mod'])
-    from handlers import simple_fsm_mod
+    from .handlers import simple_fsm_mod
 
     assert len(Router.ORDER) > 0
     assert len(Router.REGISTERED) > 0
@@ -122,7 +122,7 @@ def test_route___get___raises():
     br.wont_work("raises")
 
 
-@patch('__builtin__.reload', new=Mock(side_effect=ImportError))
+@patch('salmon.routing.reload', new=Mock(side_effect=ImportError))
 @patch('salmon.routing.LOG', new=Mock())
 def test_reload_raises():
     Router.LOG_EXCEPTIONS = True

--- a/tests/salmon_tests/setup_env.py
+++ b/tests/salmon_tests/setup_env.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 from shutil import rmtree
 
@@ -8,9 +10,9 @@ from . import dirs
 
 def clear_dir(dir_path):
     for dir_item in os.listdir(dir_path):
-        print dir_item
+        print(dir_item)
         full_path = '%s/%s' % (dir_path, dir_item)
-        print full_path
+        print(full_path)
         if os.path.isfile(full_path):
             os.unlink(full_path)
         else:

--- a/tests/salmon_tests/utils_tests.py
+++ b/tests/salmon_tests/utils_tests.py
@@ -61,7 +61,7 @@ def test_daemonize_not_fully(dc_open):
     assert not dc_open.called
     dc_open.reset_mock()
 
-    context = utils.daemonize("run/tests.pid", ".", "/tmp", 0002, do_open=True)
+    context = utils.daemonize("run/tests.pid", ".", "/tmp", 0o002, do_open=True)
     assert context
     assert dc_open.called
 


### PR DESCRIPTION
Fixes #7

* Try to avoid easy_install
* Remove win32 "support" - it was untested and couldn't be used in
  production anyway.
* Mock chardet rather than the string object
* Don't use reserved words
* Do binary file reading properly
* SMTPD messages are slightly different between Python 2 and 3
* Put test states.db in a folder that gets cleaned between test runs
* Depending on what version of Python we're using, `reload` could in one
  of three places.
* Use more modern try: except: syntax
* Print is a function in Python 3