### PR TITLE
`lmtpd.__version__` should be unicode

### DIFF
--- a/salmon/server.py
+++ b/salmon/server.py
@@ -23,7 +23,9 @@ from salmon.bounce import PRIMARY_STATUS_CODES, SECONDARY_STATUS_CODES, COMBINED
 # these need to be bytes, otherwise the opening statement looks like this:
 # \xff\xfe\x00\x002\x00\x00\x002\x00\x00\x000\x00\x00\x00.. etc.
 smtpd.__version__ = ("Salmon Mail router SMTPD, version %s" % __version__).encode()
-lmtpd.__version__ = ("Salmon Mail router LMTPD, version %s" % __version__).encode()
+
+# lmtpd expects __version__ to be a unicode object
+lmtpd.__version__ = "Salmon Mail router LMTPD, version %s" % __version__
 
 
 def undeliverable_message(raw_message, failure_type):

--- a/tests/salmon_tests/server_tests.py
+++ b/tests/salmon_tests/server_tests.py
@@ -47,8 +47,10 @@ def test_SMTPChannel(push_mock):
     assert_equal(push_mock.call_args[0][1:], (expected_version,))
     assert_equal(type(push_mock.call_args[0][1]), six.binary_type)
 
+    push_mock.reset_mock()
     channel.seen_greeting = True
     channel.smtp_MAIL("FROM: you@example.com\r\n")
+    assert_equal(push_mock.call_args[0][1:], (SMTP_MESSAGES["ok"],))
 
     push_mock.reset_mock()
     channel.smtp_RCPT("TO: me@example.com")
@@ -89,15 +91,17 @@ def test_LMTPChannel(push_mock):
     assert_equal(push_mock.call_args[0][1:], (expected_version,))
     assert_equal(type(push_mock.call_args[0][1]), six.binary_type)
 
-    channel.seen_greeting = True
-    channel.lmtp_MAIL("FROM: you@example.com\r\n")
-
     push_mock.reset_mock()
-    channel.lmtp_RCPT("TO: me@example.com")
+    channel.seen_greeting = True
+    channel.lmtp_MAIL(b"FROM: you@example.com\r\n")
     assert_equal(push_mock.call_args[0][1:], (u"250 2.1.0 Ok\r\n".encode(),))
 
     push_mock.reset_mock()
-    channel.lmtp_RCPT("TO: them@example.com")
+    channel.lmtp_RCPT(b"TO: me@example.com")
+    assert_equal(push_mock.call_args[0][1:], (u"250 2.1.0 Ok\r\n".encode(),))
+
+    push_mock.reset_mock()
+    channel.lmtp_RCPT(b"TO: them@example.com")
     assert_equal(push_mock.call_args[0][1:], (u"250 2.1.0 Ok\r\n".encode(),))
 
 


### PR DESCRIPTION
Despite writing most of lmtpd myself, I forgot that it actually encodes `__version__` to bytes.

Also included `lmptd.LMTPChannel` in tests - we don't make any changes to it really, but it should be tested anyway.