### PR TITLE
Fix regression in 4855991

### DIFF
--- a/salmon/encoding.py
+++ b/salmon/encoding.py
@@ -71,6 +71,7 @@ from __future__ import print_function, unicode_literals
 
 from email import encoders
 from email.charset import Charset
+from email.header import Header
 from email.message import Message
 from email.mime.base import MIMEBase
 from email.utils import parseaddr
@@ -509,7 +510,7 @@ def header_from_mime_encoding(header):
         return header
     elif isinstance(header, list):
         return [properly_decode_header(h) for h in header]
-    elif isinstance(header, email.header.Header):
+    elif isinstance(header, Header):
         return six.text_type(header)
     else:
         return properly_decode_header(header)


### PR DESCRIPTION
This commit fixes a regression in 4855991 which is raising an
`AttributeError` on both 2.7.5 and 3.6.5.

```bash
$ pyenv shell 3.6.5; python -c "import email; assert email.header.Header"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: module 'email' has no attribute 'header'
```