### PR TITLE
Remove completely superfluous statements from header_from_mime_encoding

### DIFF
--- a/salmon/encoding.py
+++ b/salmon/encoding.py
@@ -512,8 +512,6 @@ def header_from_mime_encoding(header):
         return header
     elif isinstance(header, list):
         return [properly_decode_header(h) for h in header]
-    elif isinstance(header, email.header.Header):
-        return six.text_type(header)
     else:
         return properly_decode_header(header)
 


### PR DESCRIPTION
Specifically the test for email.header.Header:

* It's not ever used by Salmon (no test coverage)
* email.header is not initially populated (despite appearing in
  email.__all__) which can cause problems if Salmon is being used as
  library rather than an application

Closes #71