### PR TITLE
process_message should allow extra kwargs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+.. _three-zero-one:
+
+3.0.1
+=====
+
+- ``SMTPReceiver.process_messsage`` now accepts keyword arguments added in
+  Python 3
+
 .. _three-zero-zero:
 
 3.0.0

--- a/salmon/server.py
+++ b/salmon/server.py
@@ -218,7 +218,7 @@ class SMTPReceiver(smtpd.SMTPServer):
             conn, addr = pair
             SMTPChannel(self, conn, addr)
 
-    def process_message(self, Peer, From, To, Data):
+    def process_message(self, Peer, From, To, Data, **kwargs):
         """
         Called by smtpd.SMTPServer when there's a message received.
         """
@@ -273,7 +273,7 @@ class LMTPReceiver(lmtpd.LMTPServer):
         self.poller = threading.Thread(target=asyncore.loop, kwargs={'timeout': 0.1, 'use_poll': True})
         self.poller.start()
 
-    def process_message(self, Peer, From, To, Data):
+    def process_message(self, Peer, From, To, Data, **kwargs):
         """
         Called by lmtpd.LMTPServer when there's a message received.
         """

--- a/tests/salmon_tests/server_tests.py
+++ b/tests/salmon_tests/server_tests.py
@@ -84,6 +84,12 @@ def test_SMTPReceiver_process_message():
         response = receiver.process_message(msg.Peer, msg.From, msg.To, str(msg))
         assert_equal(response, "450 Not found")
 
+    # Python 3's smtpd takes some extra kawrgs, but i we don't care about that at the moment
+    with patch("salmon.server.routing.Router") as router_mock, \
+            patch("salmon.server.undeliverable_message"):
+        response = receiver.process_message(msg.Peer, msg.From, msg.To, str(msg), mail_options=[], rcpt_options=[])
+        assert response is None, response
+
 
 @patch("lmtpd.asynchat.async_chat.push")
 def test_LMTPChannel(push_mock):
@@ -127,6 +133,12 @@ def test_LMTPReceiver_process_message():
         router_mock.deliver.side_effect = server.SMTPError(450, "Not found")
         response = receiver.process_message(msg.Peer, msg.From, msg.To, str(msg))
         assert_equal(response, "450 Not found")
+
+    # lmtpd's server is a subclass of smtpd's server, so we should support the same kwargs here
+    with patch("salmon.server.routing.Router") as router_mock, \
+            patch("salmon.server.undeliverable_message"):
+        response = receiver.process_message(msg.Peer, msg.From, msg.To, str(msg), mail_options=[], rcpt_options=[])
+        assert response is None, response
 
 
 @patch("salmon.queue.Queue")


### PR DESCRIPTION
Python 3 adds some extra kwargs that we're unlikely to use, but should
still be accepted