### PR TITLE
QueueReceiver now uses threads

### DIFF
--- a/salmon/server.py
+++ b/salmon/server.py
@@ -4,6 +4,7 @@ relays, and queue processors.
 """
 from __future__ import print_function, unicode_literals
 
+from multiprocessing.dummy import Pool
 import asyncore
 import logging
 import smtpd
@@ -306,46 +307,50 @@ class QueueReceiver(object):
     same way otherwise.
     """
 
-    def __init__(self, queue_dir, sleep=10, size_limit=0, oversize_dir=None):
+    def __init__(self, queue_dir, sleep=10, size_limit=0, oversize_dir=None, workers=10):
         """
-        The router should be fully configured and ready to work, the
-        queue_dir can be a fully qualified path or relative.
+        The router should be fully configured and ready to work, the queue_dir
+        can be a fully qualified path or relative. The option workers dictates
+        how many threads are started to process messages. Consider adding
+        ``@nolocking`` to your handlers if you are able to.
         """
         self.queue = queue.Queue(queue_dir, pop_limit=size_limit,
                                  oversize_dir=oversize_dir)
-        self.queue_dir = queue_dir
         self.sleep = sleep
+
+        # Pool is from multiprocess.dummy which uses threads rather than processes
+        self.workers = Pool(workers)
 
     def start(self, one_shot=False):
         """
         Start simply loops indefinitely sleeping and pulling messages
         off for processing when they are available.
 
-        If you give one_shot=True it will run once rather than do a big
-        while loop with a sleep.
+        If you give one_shot=True it will stop once it has exhausted the queue
         """
 
-        logging.info("Queue receiver started on queue dir %s", self.queue_dir)
+        logging.info("Queue receiver started on queue dir %s", self.queue.dir)
         logging.debug("Sleeping for %d seconds...", self.sleep)
 
-        inq = queue.Queue(self.queue_dir)
-
-        while True:
-            keys = inq.keys()
-
-            for key in keys:
-                msg = inq.get(key)
-
-                if msg:
-                    logging.debug("Pulled message with key: %r off", key)
-                    self.process_message(msg)
-                    logging.debug("Removed %r key from queue.", key)
-                    inq.remove(key)
-
-            if one_shot:
-                return
-            else:
+        # if there are no messages left in the maildir and this a one-shot, the
+        # while loop terminates
+        while not (self.queue.count() == 0 and one_shot):
+            # if there's nothing in the queue, take a break
+            if self.queue.count() == 0:
                 time.sleep(self.sleep)
+                continue
+
+            try:
+                key, msg = self.queue.pop()
+            except KeyError:
+                logging.debug("Could not find message in Queue")
+                continue
+
+            logging.debug("Pulled message with key: %r off", key)
+            self.workers.apply_async(self.process_message, args=(msg,))
+
+        self.workers.close()
+        self.workers.join()
 
     def process_message(self, msg):
         """
@@ -357,7 +362,6 @@ class QueueReceiver(object):
             logging.debug("Message received from Peer: %r, From: %r, to To %r.", msg.Peer, msg.From, msg.To)
             routing.Router.deliver(msg)
         except SMTPError as err:
-            # looks like they want to return an error, so send it out
             logging.exception("Raising SMTPError when running in a QueueReceiver is unsupported.")
             undeliverable_message(msg.Data, err.message)
         except Exception:


### PR DESCRIPTION
Only for message processing though. The fetching of messages from the Queue is
still done in the main thread because Queues are not threadsafe.

It also fixes an issue with QueueReceiver not respecting the size_limit
and oversize_dir kwargs.

These changes will only help performance where at least one of your handlers has the `nolocking` decorator applied.

See #67 for discussion.