### PR TITLE
Give queue a   len  

### DIFF
--- a/salmon/commands.py
+++ b/salmon/commands.py
@@ -228,7 +228,7 @@ def queue(name, pop=False, get=False, keys=False, remove=False, count=False, cle
     elif remove:
         inq.remove(remove)
     elif count:
-        click.echo("Queue %s contains %d messages" % (name, inq.count()))
+        click.echo("Queue %s contains %d messages" % (name, len(inq)))
     elif clear:
         inq.clear()
     elif keys:

--- a/salmon/data/prototype/tests/handlers/open_relay_tests.py
+++ b/salmon/data/prototype/tests/handlers/open_relay_tests.py
@@ -22,6 +22,6 @@ def test_drops_open_relay_messages():
     """
     client.begin()
     client.say("tester@badplace.notinterwebs", "Relay should not happen")
-    assert queue().count() == 0, "You are configured currently to accept everything. " \
-                                 "You should change config/settings.py router_defaults " \
-                                 "so host is your actual host name that will receive mail."
+    assert len(queue()) == 0, "You are configured currently to accept everything. " \
+                              "You should change config/settings.py router_defaults " \
+                              "so host is your actual host name that will receive mail."

--- a/salmon/queue.py
+++ b/salmon/queue.py
@@ -159,9 +159,12 @@ class Queue(object):
         """Removes the queue, but not returned."""
         self.mbox.remove(key)
 
-    def count(self):
+    def __len__(self):
         """Returns the number of messages in the queue."""
         return len(self.mbox)
+
+    # synonym of __len__ for backwards compatibility
+    count = __len__
 
     def clear(self):
         """
@@ -170,7 +173,7 @@ class Queue(object):
         basically pops until the queue is empty.
         """
         # man this is probably a really bad idea
-        while self.count() > 0:
+        while len(self) > 0:
             self.pop()
 
     def keys(self):

--- a/salmon/queue.py
+++ b/salmon/queue.py
@@ -169,8 +169,11 @@ class Queue(object):
     def clear(self):
         """
         Clears out the contents of the entire queue.
-        Warning: This could be horribly inefficient since it
-        basically pops until the queue is empty.
+
+        Warning: This could be horribly inefficient since it pops messages
+        until the queue is empty. It could also cause an infinite loop if
+        another process is writing to messages to the Queue faster than we can
+        pop.
         """
         # man this is probably a really bad idea
         while len(self) > 0:

--- a/salmon/routing.py
+++ b/salmon/routing.py
@@ -323,7 +323,7 @@ class RoutingBase(object):
                     yield func, matchkw
 
     def _enqueue_undeliverable(self, message):
-        if self.UNDELIVERABLE_QUEUE:
+        if self.UNDELIVERABLE_QUEUE is not None:
             LOG.debug("Message to %r from %r undeliverable, putting in undeliverable queue (# of recipients: %d).",
                       message.To, message.From, len(message.To))
             self.UNDELIVERABLE_QUEUE.push(message)
@@ -385,7 +385,7 @@ class RoutingBase(object):
         except Exception:
             self.set_state(func.__module__, message, 'ERROR')
 
-            if self.UNDELIVERABLE_QUEUE:
+            if self.UNDELIVERABLE_QUEUE is not None:
                 self.UNDELIVERABLE_QUEUE.push(message)
 
             if self.LOG_EXCEPTIONS:

--- a/salmon/server.py
+++ b/salmon/server.py
@@ -33,7 +33,7 @@ def undeliverable_message(raw_message, failure_type):
     Used universally in this file to shove totally screwed messages
     into the routing.Router.UNDELIVERABLE_QUEUE (if it's set).
     """
-    if routing.Router.UNDELIVERABLE_QUEUE:
+    if routing.Router.UNDELIVERABLE_QUEUE is not None:
         key = routing.Router.UNDELIVERABLE_QUEUE.push(raw_message)
 
         logging.error("Failed to deliver message because of %r, put it in "
@@ -334,9 +334,9 @@ class QueueReceiver(object):
 
         # if there are no messages left in the maildir and this a one-shot, the
         # while loop terminates
-        while not (self.queue.count() == 0 and one_shot):
+        while not (len(self.queue) == 0 and one_shot):
             # if there's nothing in the queue, take a break
-            if self.queue.count() == 0:
+            if len(self.queue) == 0:
                 time.sleep(self.sleep)
                 continue
 

--- a/tests/command_tests.py
+++ b/tests/command_tests.py
@@ -56,7 +56,7 @@ class CommandTestCase(SalmonTestCase):
         mq.get.return_value = "A sample message"
         mq.keys.return_value = ["key1", "key2"]
         mq.pop.return_value = ('key1', 'message1')
-        mq.count.return_value = 1
+        mq.__len__.return_value = 1
 
         runner = CliRunner()
 
@@ -76,7 +76,7 @@ class CommandTestCase(SalmonTestCase):
         self.assertEqual(mq.keys.call_count, 1)
 
         runner.invoke(commands.main, ("queue", "--count"))
-        self.assertEqual(mq.count.call_count, 1)
+        self.assertEqual(mq.__len__.call_count, 1)
 
     @patch('salmon.utils.daemonize', new=Mock())
     @patch('salmon.server.SMTPReceiver')

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -2,6 +2,7 @@ from shutil import rmtree
 import os
 import smtplib
 import subprocess
+import sys
 import time
 
 from salmon import queue
@@ -18,7 +19,7 @@ class IntegrationTestCase(SalmonTestCase):
             rmtree(os.path.join(cls._cwd, path), ignore_errors=True)
             os.mkdir(os.path.join(cls._cwd, path))
         cls._server = subprocess.Popen(["salmon", "start", "--boot", "config.dump", "--no-daemon"],
-                                       cwd=cls._cwd)
+                                       cwd=cls._cwd, stdout=sys.stdout, stderr=sys.stderr)
         for i in range(5):
             try:
                 conn = smtplib.SMTP(**server_settings.receiver_config)
@@ -51,10 +52,10 @@ class IntegrationTestCase(SalmonTestCase):
         client.sendmail("me@example.com", "you@example.com", "hello")
 
         undelivered = queue.Queue(os.path.join(self._cwd, server_settings.UNDELIVERABLE_QUEUE))
-        self.assertEqual(len(undelivered.mbox), 0)
+        self.assertEqual(len(undelivered), 0)
 
         inbox = queue.Queue(os.path.join(self._cwd, server_settings.QUEUE_PATH))
-        self.assertEqual(len(inbox.mbox), 1)
+        self.assertEqual(len(inbox), 1)
 
     def test_we_dont_get_message(self):
         client = smtplib.SMTP(**server_settings.receiver_config)
@@ -63,7 +64,7 @@ class IntegrationTestCase(SalmonTestCase):
         client.sendmail("me@example.com", "you@example1.com", "hello")
 
         undelivered = queue.Queue(os.path.join(self._cwd, server_settings.UNDELIVERABLE_QUEUE))
-        self.assertEqual(len(undelivered.mbox), 1)
+        self.assertEqual(len(undelivered), 1)
 
         inbox = queue.Queue(os.path.join(self._cwd, server_settings.QUEUE_PATH))
-        self.assertEqual(len(inbox.mbox), 0)
+        self.assertEqual(len(inbox), 0)

--- a/tests/queue_tests.py
+++ b/tests/queue_tests.py
@@ -153,3 +153,11 @@ class QueueTestCase(SalmonTestCase):
         self.assertEqual(mail['to'], "you@localhost")
         self.assertEqual(mail['subject'], "bob!")
         self.assertEqual(mail.body(), "Blobcat")
+
+    def test_len(self):
+        q = self.test_push()
+        self.assertEqual(len(q), 1)
+
+    def test_count(self):
+        q = self.test_push()
+        self.assertEqual(q.count(), 1)

--- a/tests/server_tests.py
+++ b/tests/server_tests.py
@@ -282,9 +282,10 @@ class ServerTestCase(SalmonTestCase):
     @patch("salmon.server.queue.Queue")
     def test_queue_receiver_pop_error(self, queue_mock, router_mock):
         def key_error(*args, **kwargs):
-            queue_mock.return_value.count.return_value = 0
+            queue_mock.return_value.__len__.return_value = 0
             raise KeyError
 
+        queue_mock.return_value.__len__.return_value = 1
         queue_mock.return_value.pop.side_effect = key_error
         receiver = server.QueueReceiver('run/queue')
         receiver.start(one_shot=True)


### PR DESCRIPTION
- It's more Pythonic as `len(obj)` is something most of us expect to be able to use
- `Queue().count()` still works, so there's no need to rewrite old code
- Also fixed a few places where we had `if myQueue:` where we meant `if myQueue is not None:`