### PR TITLE
Fix test deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ install_requires = [
 
 tests_require = [
     'jinja2<3.0',
-    'mock',
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 tests_require = [
-    'jinja2',
+    'jinja2<3.0',
     'mock',
 ]
 

--- a/tests/command_tests.py
+++ b/tests/command_tests.py
@@ -1,10 +1,10 @@
 from tempfile import mkdtemp
+from unittest.mock import Mock, patch
 import mailbox
 import os
 import sys
 
 from click import testing
-from mock import Mock, patch
 
 from salmon import queue, commands, encoding, mail, routing, utils
 

--- a/tests/confirm_tests.py
+++ b/tests/confirm_tests.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from salmon import mail, view
 from salmon.confirm import ConfirmationEngine, ConfirmationStorage

--- a/tests/encoding_tests.py
+++ b/tests/encoding_tests.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from email import encoders
 from email.utils import parseaddr
+from unittest.mock import Mock, patch
 import mailbox
 import os
 
-from mock import Mock, patch
 import chardet
 
 from salmon import encoding

--- a/tests/handler_tests.py
+++ b/tests/handler_tests.py
@@ -1,6 +1,5 @@
+from unittest.mock import Mock
 import sys
-
-from mock import Mock
 
 from salmon import mail, utils
 from salmon.routing import Router

--- a/tests/queue_tests.py
+++ b/tests/queue_tests.py
@@ -1,8 +1,7 @@
+from unittest.mock import Mock, patch
 import mailbox
 import os
 import shutil
-
-from mock import Mock, patch
 
 from salmon import mail, queue
 

--- a/tests/routing_tests.py
+++ b/tests/routing_tests.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from salmon import routing
 from salmon.mail import MailRequest

--- a/tests/server_tests.py
+++ b/tests/server_tests.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2008 Zed A. Shaw.  Licensed under the terms of the GPLv3.
+from unittest.mock import Mock, call, patch
 import socket
 import sys
 
-from mock import Mock, call, patch
 import lmtpd
 
 from salmon import mail, queue, routing, server

--- a/tests/testing_tests.py
+++ b/tests/testing_tests.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from salmon.testing import RouterConversation, assert_in_state, clear_queue, delivered, queue, relay
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,8 +1,7 @@
 from tempfile import mkdtemp
 from unittest import TestCase
+from unittest.mock import patch
 import os
-
-from mock import patch
 
 from salmon import utils
 


### PR DESCRIPTION
- Jinja 3.0 won't support Python 3.5
- mock is now part of the Python stdlib