### PR TITLE
Stop locking on every handler call

### DIFF
--- a/salmon/handlers/queue.py
+++ b/salmon/handlers/queue.py
@@ -8,16 +8,14 @@ the salmon queue command.
 import logging
 
 from salmon import handlers, queue
-from salmon.routing import nolocking, route_like, stateless
+from salmon.routing import route_like, stateless
 
 
 @route_like(handlers.log.START)
 @stateless
-@nolocking
 def START(message, to=None, host=None):
     """
     @stateless and routes however handlers.log.START routes (everything).
-    Has @nolocking, but that's alright since it's just writing to a Maildir.
     """
     logging.debug("MESSAGE to %s@%s added to queue.", to, host)
     q = queue.Queue('run/queue')

--- a/salmon/server.py
+++ b/salmon/server.py
@@ -299,8 +299,7 @@ class QueueReceiver:
         """
         The router should be fully configured and ready to work, the queue_dir
         can be a fully qualified path or relative. The option workers dictates
-        how many threads are started to process messages. Consider adding
-        ``@nolocking`` to your handlers if you are able to.
+        how many threads are started to process messages.
         """
         self.queue = queue.Queue(queue_dir, pop_limit=size_limit,
                                  oversize_dir=oversize_dir)

--- a/salmon/testing.py
+++ b/salmon/testing.py
@@ -140,3 +140,8 @@ def assert_in_state(module, To, From, state):
     state_key = routing.Router.state_key(module, fake)
     assert routing.Router.STATE_STORE.get(state_key, From) == state, \
         "%r != %r" % (routing.Router.STATE_STORE.get(state_key, From), state)
+
+
+def assert_salmon_settings(func):
+    """Used to make sure that the func has been setup by a routing decorator."""
+    assert routing.has_salmon_settings(func), "Function %s has not be setup with a @route first." % func.__name__

--- a/tests/data/test_app/test_handlers/dump.py
+++ b/tests/data/test_app/test_handlers/dump.py
@@ -1,11 +1,10 @@
 from salmon import queue
-from salmon.routing import nolocking, route, stateless
+from salmon.routing import route, stateless
 from salmon.utils import settings
 
 
 @route("(to)@(host)", to=".+", host="example.com")
 @stateless
-@nolocking
 def START(message, to=None, host=None):
     inbox = queue.Queue(settings.QUEUE_PATH)
     inbox.push(message)

--- a/tests/handlers/simple_fsm_mod.py
+++ b/tests/handlers/simple_fsm_mod.py
@@ -1,4 +1,4 @@
-from salmon.routing import Router, nolocking, route, route_like, state_key_generator, stateless
+from salmon.routing import Router, route, route_like, state_key_generator, stateless
 
 
 @state_key_generator
@@ -47,28 +47,5 @@ def END(message, anything=None, host=None):
 
 @route(".*")
 @stateless
-@nolocking
 def PASSING(message, *args, **kw):
     print("PASSING", args, kw)
-
-
-try:
-    # `@stateless` needs to be "inside" `@route` or `@route_like`
-    @stateless
-    @route("badstateless@(host)")
-    def BAD_STATELESS(message, *args, **kw):
-        print("BAD_STATELESS", args, kw)
-except TypeError:
-    pass
-else:
-    raise AssertionError("No TypeError raised on misordered decorators")
-
-try:
-    # `@route_like should reference another function that has had `route_like` or `route`
-    @route_like(simple_key_gen)
-    def BAD_ROUTLIKE(message, *args, **kwargs):
-        pass
-except TypeError:
-    pass
-else:
-    raise AssertionError("No TypeError raised when route_like was used on a non-routed function")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -6,7 +6,7 @@ import sys
 
 from click import testing
 
-from salmon import queue, commands, encoding, mail, routing, utils
+from salmon import commands, encoding, mail, queue, routing, utils
 
 from .setup_env import SalmonTestCase
 

--- a/tests/test_confirm.py
+++ b/tests/test_confirm.py
@@ -1,10 +1,11 @@
 from unittest.mock import Mock, patch
 
+import jinja2
+
 from salmon import mail, view
 from salmon.confirm import ConfirmationEngine, ConfirmationStorage
 from salmon.queue import Queue
 from salmon.testing import delivered, relay
-import jinja2
 
 from .setup_env import SalmonTestCase
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,10 +5,11 @@ import subprocess
 import sys
 import time
 
+from test_app.config import settings as server_settings
+
 from salmon import queue
 
 from .setup_env import SalmonTestCase, dirs
-from test_app.config import settings as server_settings
 
 
 class IntegrationTestCase(SalmonTestCase):

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
-from salmon import view
 import jinja2
+
+from salmon import view
 
 
 class ViewsTestCase(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
 skip_install = true
 
 [testenv:isort]
-commands = isort --check-only --diff salmon setup.py
+commands = isort --check-only --diff salmon tests setup.py
 deps = isort
 skip_install = true
 
@@ -53,7 +53,13 @@ use_parentheses = true
 skip_glob =
     salmon/_version.py
     versioneer.py
-    tests/*
+    .eggs
+    .git
+    .tox
+    __pycache__
+    build
+    docs
+    env
 
 [gh-actions]
 python =


### PR DESCRIPTION
Salmon should have been thread-safe *and* performant from the start. This PR makes that true.

- [x] Write tests for locking handler call
- [x] Write tests for locking and nolocking decorators
- [x] Make sure state storages are thread-safe (I think they are already, but it's worth checking)
- [x] Update docs