### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Apache or Nginx. It has all the features of a web application stack (templates,
 routing, handlers, state machine) and plays well with other libraries, such as
 Django and SQLAlchemy.
 
-Salmon has been released uner the GNU GPLv3, as published by the FSF.
+Salmon has been released under the GNU GPLv3, as published by the FSF.
 
 Features
 ========

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -344,7 +344,7 @@ epub_copyright = copyright
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/salmon/commands.py
+++ b/salmon/commands.py
@@ -18,7 +18,7 @@ from salmon import routing, server, utils
 import salmon
 
 # squash warning about unicode literals. if there are bugs here, then it's
-# quite likely to have afffected us before switching to click.
+# quite likely to have affected us before switching to click.
 click.disable_unicode_literals_warning = True
 
 DEFAULT_PID_FILE = "./run/smtp.pid"
@@ -266,7 +266,7 @@ def routes(modules, test, path):
     messages not getting to your handlers.  Path has the search paths you want
     separated by a ':' character, and it's added to the sys.path.
 
-    MODULE should be a configureation module and can be given multiple times.
+    MODULE should be a configuration module and can be given multiple times.
     """
     _import_router_modules(modules, path)
     test_case_matches = []

--- a/salmon/routing.py
+++ b/salmon/routing.py
@@ -12,7 +12,7 @@ there's usually only one.
 The salmon.routing.StateStorage is what you need to implement if you want
 Salmon to store the state in a different way.  By default the
 salmon.routing.Router object just uses a default MemoryStorage to do its job.
-If you want to use a custom storage, then in your boot modiule you would set
+If you want to use a custom storage, then in your boot module you would set
 salmon.routing.Router.STATE_STORE to what you want to use.
 
 Finally, when you write a state handler, it has functions that act as state

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,7 @@ class IntegrationTestCase(SalmonTestCase):
 
     def setUp(self):
         super().setUp()
-        # re-create destoryed queues
+        # re-create destroyed queues
         queue.Queue(os.path.join(self._cwd, server_settings.UNDELIVERABLE_QUEUE)).clear()
         queue.Queue(os.path.join(self._cwd, server_settings.QUEUE_PATH)).clear()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -318,7 +318,7 @@ class ServerTestCase(SalmonTestCase):
         args = receiver.workers.apply_async.call_args[1]["args"]
         del receiver.workers.apply_async.call_args[1]["args"]
 
-        # onlly the "args" kwarg should be present
+        # only the "args" kwarg should be present
         self.assertEqual(receiver.workers.apply_async.call_args[1], {})
 
         # we can't compare two Mail* objects, so we'll just check the type


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/conf.py
- salmon/commands.py
- salmon/routing.py
- tests/test_integration.py
- tests/test_server.py

Fixes:
- Should read `under` rather than `uner`.
- Should read `that` rather than `shat`.
- Should read `only` rather than `onlly`.
- Should read `module` rather than `modiule`.
- Should read `destroyed` rather than `destoryed`.
- Should read `configuration` rather than `configureation`.
- Should read `affected` rather than `afffected`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md